### PR TITLE
Notion authtest fix

### DIFF
--- a/shipyard_blueprints/notion/shipyard_notion/cli/authtest.py
+++ b/shipyard_blueprints/notion/shipyard_notion/cli/authtest.py
@@ -1,17 +1,19 @@
 import os
 import sys
-from shipyard_notion import NotionClient
+import requests
 
 
 def main():
-    try:
-        client = NotionClient(token=os.getenv("NOTION_ACCESS_TOKEN"))
-        c = client.connect()
-    except Exception as e:
-        print(f"Could not connect to Notion with the provided access token due to {e}")
+    token = os.getenv('NOTION_ACCESS_TOKEN')
+    headers = {'Authorization': f'Bearer {token}',
+               'accept': 'application/json',
+               'Notion-Version': '2022-06-28'}
+    url = 'https://api.notion.com/v1/users/me'
+    resp = requests.get(url, headers = headers)
+    if not resp.ok:
+        print(f"Could not connect to Notion with the provided access token: {resp.text}")
         sys.exit(1)
-    else:
-        sys.exit(0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/shipyard_blueprints/notion/shipyard_notion/cli/authtest.py
+++ b/shipyard_blueprints/notion/shipyard_notion/cli/authtest.py
@@ -4,14 +4,18 @@ import requests
 
 
 def main():
-    token = os.getenv('NOTION_ACCESS_TOKEN')
-    headers = {'Authorization': f'Bearer {token}',
-               'accept': 'application/json',
-               'Notion-Version': '2022-06-28'}
-    url = 'https://api.notion.com/v1/users/me'
-    resp = requests.get(url, headers = headers)
+    token = os.getenv("NOTION_ACCESS_TOKEN")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "accept": "application/json",
+        "Notion-Version": "2022-06-28",
+    }
+    url = "https://api.notion.com/v1/users/me"
+    resp = requests.get(url, headers=headers)
     if not resp.ok:
-        print(f"Could not connect to Notion with the provided access token: {resp.text}")
+        print(
+            f"Could not connect to Notion with the provided access token: {resp.text}"
+        )
         sys.exit(1)
     sys.exit(0)
 

--- a/shipyard_blueprints/notion/shipyard_notion/cli/authtest.py
+++ b/shipyard_blueprints/notion/shipyard_notion/cli/authtest.py
@@ -17,6 +17,7 @@ def main():
             f"Could not connect to Notion with the provided access token: {resp.text}"
         )
         sys.exit(1)
+    print("Successfully connected to Notion!")
     sys.exit(0)
 
 


### PR DESCRIPTION
Refactored `cli/authtest.py`  to not import package but to instead use `requests` to query the `me` endpoint