### PR TITLE
Bugfix/add failure when no files found

### DIFF
--- a/shipyard_blueprints/googledrive/pyproject.toml
+++ b/shipyard_blueprints/googledrive/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shipyard-googledrive"
-version = "0.1.1a9"
+version = "0.1.1a10"
 description = "A local client for connecting and working with Google Drive"
 authors = ["wrp801 <wespoulsen@gmail.com>"]
 license = "Apache 2.0"

--- a/shipyard_blueprints/googledrive/shipyard_googledrive/cli/upload.py
+++ b/shipyard_blueprints/googledrive/shipyard_googledrive/cli/upload.py
@@ -4,7 +4,7 @@ import argparse
 import re
 
 from shipyard_templates import ExitCodeException
-from shipyard_googledrive import GoogleDriveClient
+from shipyard_googledrive import GoogleDriveClient, drive_utils
 from shipyard_bp_utils import files
 
 
@@ -41,7 +41,6 @@ def main():
         service_account=args.service_account, shared_drive_name=args.drive
     )
     if args.source_folder_name != "":
-        # source_path = args.source_file_name
         source_path = os.path.join(args.source_folder_name, args.source_file_name)
     else:
         source_path = args.source_file_name
@@ -57,13 +56,18 @@ def main():
     # for multiple file uploads
 
     if args.source_file_name_match_type == "regex_match":
-        files_listed = files.find_all_local_file_names(
+        files_listed = drive_utils.list_local_files(
             args.source_folder_name if args.source_folder_name != "" else None
         )
         file_matches = files.find_all_file_matches(
             file_names=files_listed,
             file_name_re=re.compile(args.source_file_name),
         )
+        if len(file_matches) == 0:
+            client.logger.error(
+                f"No files found matching regex {args.source_file_name}"
+            )
+            sys.exit(client.EXIT_CODE_FILE_NOT_FOUND)
         for index, file in enumerate(file_matches, start=1):
             if args.source_folder_name:
                 file_path = os.path.join(args.source_folder_name, file)

--- a/shipyard_blueprints/googledrive/shipyard_googledrive/drive_utils.py
+++ b/shipyard_blueprints/googledrive/shipyard_googledrive/drive_utils.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import re
+import glob
 from typing import Optional, Union, List, Any, Set
 
 from shipyard_templates import ExitCodeException
@@ -408,3 +409,19 @@ def get_all_folder_ids(service, drive_id: Optional[str] = None) -> List[Any]:
     folder_ids = [folder["id"] for folder in folders]
     # folder_ids.append('root') # add so that the files not within a folder will be returned as well
     return folder_ids
+
+
+def list_local_files(dirname: Optional[str]) -> List[str]:
+    """Returns all the files located within the directory path. If the dirname is not provided, then the current working directory will be used
+
+    Args:
+        dirname: The optional directory to span
+
+    Returns: List of all the files
+
+    """
+    cwd = os.getcwd()
+    if dirname:
+        cwd = os.path.join(cwd, dirname)
+    files = os.listdir(cwd)
+    return [file for file in files if os.path.isfile(file)]


### PR DESCRIPTION
- Created a helper function to list all local files (only applicable for `regex_match` options) instead of using the function from shipyard-utils